### PR TITLE
Updated the schema and the example to objectify options and add hasOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Options
 
-This extension adds a field for information on options.
+This extension adds a field to indicated whether options are used and an object for information on options.
 
 ## Usage
 
-A buyer may have a right – but not an obligation – to additional purchases from a supplier while the contract is valid. The `tender/options` field should describe this option for additional purchases.
+A buyer may have a right – but not an obligation – to additional purchases from a supplier while the contract is valid.
+
+The `tender.hasOptions` field should be set to `true`, and `tender.options.description` field should describe this option for additional purchases. `.hasOptions` and `.options` can also be set at `Lot` (`tender.lots` array).
 
 For example, a contract may concern a thousand uniforms, and the buyer may have the option to request an additional hundred uniforms. This may be useful if, when initiating the contracting process, the buyer doesn't yet know whether a planned increase in staff will take place.¹
 
@@ -19,7 +21,10 @@ The European Union is a [party](https://www.wto.org/english/tratop_e/gproc_e/mem
 ```json
 {
   "tender": {
-    "options": "The buyer has the option to buy an additional hundred uniforms."
+    "hasOptions": true,
+    "options": {
+      "description": "The buyer has the option to buy an additional hundred uniforms."
+    }
   }
 }
 ```

--- a/release-schema.json
+++ b/release-schema.json
@@ -9,7 +9,11 @@
         },
         "hasOptions": {
           "title": "Options used",
-          "description": "Whether or not the buyer reserves the right to make additional purchases from the supplier, as long as the contract is valid."
+          "description": "Whether or not the buyer reserves the right to make additional purchases from the supplier, as long as the contract is valid.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },
@@ -22,11 +26,18 @@
         },
         "hasOptions": {
           "title": "Options used",
-          "description": "Whether or not the buyer reserves the right to make additional purchases from the supplier, as long as the contract is valid."
+          "description": "Whether or not the buyer reserves the right to make additional purchases from the supplier, as long as the contract is valid.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },
     "Options": {
+      "title": "Options",
+      "description": "A description of the options.",
+      "type": "object",
       "properties": {
         "description": {
           "title": "Options description",

--- a/release-schema.json
+++ b/release-schema.json
@@ -4,11 +4,12 @@
       "properties": {
         "options": {
           "title": "Options",
-          "description": "A description of any options.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "A description of the options.",
+          "$ref": "#/definitions/Options"
+        },
+        "hasOptions": {
+          "title": "Options used",
+          "description": "Whether or not the buyer reserves the right to make additional purchases from the supplier, as long as the contract is valid."
         }
       }
     },
@@ -16,7 +17,20 @@
       "properties": {
         "options": {
           "title": "Options",
-          "description": "A description of any options.",
+          "description": "A description of the options.",
+          "$ref": "#/definitions/Options"
+        },
+        "hasOptions": {
+          "title": "Options used",
+          "description": "Whether or not the buyer reserves the right to make additional purchases from the supplier, as long as the contract is valid."
+        }
+      }
+    },
+    "Options": {
+      "properties": {
+        "description": {
+          "title": "Options description",
+          "description": "A description of the options.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
Updated the extension to catch up with the new mappings: https://github.com/open-contracting-extensions/european-union/issues/21#issuecomment-523292857