### PR TITLE
Add the recoursePeriod field to the Options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The European Union is a [party](https://www.wto.org/english/tratop_e/gproc_e/mem
     "hasOptions": true,
     "options": {
       "description": "The buyer has the option to buy an additional hundred uniforms.",
-      "recoursePeriod": {
+      "period": {
         "durationInDays": 180
       }
     }
@@ -44,7 +44,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ### 2020-10-06
 
-* Add the `recoursePeriod` field to the `Options` object.
+* Add the `period` field to the `Options` object.
 
 ### 2020-04-24
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ The European Union is a [party](https://www.wto.org/english/tratop_e/gproc_e/mem
   "tender": {
     "hasOptions": true,
     "options": {
-      "description": "The buyer has the option to buy an additional hundred uniforms."
+      "description": "The buyer has the option to buy an additional hundred uniforms.",
+      "recoursePeriod": {
+        "durationInDays": 180
+      }
     }
   }
 }
@@ -38,6 +41,10 @@ The European Union is a [party](https://www.wto.org/english/tratop_e/gproc_e/mem
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2020-10-06
+
+* Add the `recoursePeriod` field to the `Options` object.
 
 ### 2020-04-24
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -47,6 +47,11 @@
             "null"
           ],
           "minLength": 1
+        },
+        "recoursePeriod": {
+          "title": "Recourse period",
+          "description": "The period over which the options can be used.",
+          "$ref": "#/definitions/Period"
         }
       },
       "minProperties": 1

--- a/release-schema.json
+++ b/release-schema.json
@@ -48,8 +48,8 @@
           ],
           "minLength": 1
         },
-        "recoursePeriod": {
-          "title": "Recourse period",
+        "period": {
+          "title": "Period",
           "description": "The period over which the options can be used.",
           "$ref": "#/definitions/Period"
         }


### PR DESCRIPTION
```
"recoursePeriod": {
          "title": "Recourse period",
          "description": "The period over which the options can be used.",
          "$ref": "#/definitions/Period"
        }
```

I used "used" as it's the verb used [in the directive](https://eur-lex.europa.eu/legal-content/EN/TXT/?qid=1585836130257&uri=CELEX:32014L0024#d1e6277-65-1) (Article 72, paragraph 1. a). I also found "exercised", but I wasn't sure it wasn't used with "option" in a broader sense.

Closes https://github.com/open-contracting-extensions/european-union/issues/82